### PR TITLE
fix: update git user configuration for signing commits

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,13 +65,13 @@ jobs:
        # Configure git to sign commits/tags with the imported key
       - name: Configure git signing
         run: |
-          git config --global user.name  "CI Bot"
+          git config --global user.name  "deresegetachew"
           git config --global user.email "deresegetachew@gmail.com"
           git config --global commit.gpgsign true
           git config --global tag.gpgSign true
           git config --global user.signingkey ${{ steps.gpg.outputs.keyid }}
 
-      # Set up authentication to push changes using the bot token
+      # Set up authentication to push changes using the bot / pat token
       - name: Set up auth with bot token
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.BOT_TOKEN }}@github.com/${{ github.repository }}.git


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration. The most notable change is updating the git user information used for signing commits and tags.

* Changed the global git user name from "CI Bot" to "deresegetachew" and updated the associated email to "deresegetachew@gmail.com" in `.github/workflows/main.yaml`.