### PR TITLE
feat: enhance git configuration for commit signing and identity verif… [skip changeset check]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,12 +70,25 @@ jobs:
           git config --global commit.gpgsign true
           git config --global tag.gpgSign true
           git config --global user.signingkey ${{ steps.gpg.outputs.keyid }}
+          git config --global user.useConfigOnly true # Ensures git uses the configured user.name and user.email only and not bot defaults
+          echo "GIT_AUTHOR_NAME=deresegetachew" >> $GITHUB_ENV # Set env vars for commit author/committer
+          echo "GIT_AUTHOR_EMAIL=deresegetachew@gmail.com" >> $GITHUB_ENV # Set env vars for commit author/committer
+          echo "GIT_COMMITTER_NAME=deresegetachew" >> $GITHUB_ENV # Set env vars for commit author/committer
+          echo "GIT_COMMITTER_EMAIL=deresegetachew@gmail.com" >> $GITHUB_ENV # Set env vars for commit author/committer
 
       # Set up authentication to push changes using the bot / pat token
       - name: Set up auth with bot token
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.BOT_TOKEN }}@github.com/${{ github.repository }}.git
-          
+
+      # Debugging step to verify git identity configuration
+      - name: Debug commit identity
+        run: |
+          echo "Git identity:"
+          git config --get user.name
+          git config --get user.email
+          echo "Env identity:"
+          env | grep -E 'GIT_(AUTHOR|COMMITTER)_' || true
       # Download build artifacts to the 'packages' directory
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to ensure that commits and tags are correctly attributed to the intended user rather than the default GitHub Actions bot. It also adds a debugging step to verify the commit identity configuration during workflow runs.

**Improvements to Git commit attribution:**

* Added `git config --global user.useConfigOnly true` to force Git to use the explicitly configured `user.name` and `user.email` instead of any defaults.
* Set environment variables (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`) to ensure that commit and tag authorship is correctly attributed.

**Debugging and verification:**

* Introduced a new workflow step to print out the configured Git identity and related environment variables for easier debugging of commit attribution issues.